### PR TITLE
Fix: Remove unused React import in Dashboard component

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export function Dashboard() {
   const projects = [
     { id: 'PWA001', name: 'Hello World PWA', status: 'Completed', date: 'Dec 3, 2024' },


### PR DESCRIPTION
This PR removes the unused React import from the Dashboard component. With Vite and modern React, explicit React imports are not needed for JSX usage.

Changes:
- Remove unused React import from Dashboard.tsx
- Fixes TypeScript build error TS6133