### PR TITLE
Restore previous dashboard layout with current data

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,64 +1,38 @@
-export function Dashboard() {
-  const projects = [
-    { id: 'PWA001', name: 'Hello World PWA', status: 'Completed', date: 'Dec 3, 2024' },
-    { id: 'PWA002', name: 'Voice Synthesis', status: 'Completed', date: 'Dec 4-5, 2024' },
-    { id: 'PWA003', name: 'Project Dashboard', status: 'Completed', date: 'Dec 6, 2024' },
-    { id: 'PWA004', name: 'Speech to Text', status: 'Completed', date: 'Dec 7-8, 2024' },
-    { id: 'PWA005', name: 'Claude Chat PWA', status: 'Completed', date: 'Dec 9, 2024' },
-    { id: 'PWA006', name: 'Voice AI Assistant', status: 'In Progress', date: 'Dec 10, 2024' },
-  ];
+import { ProjectList } from './ProjectList'
+import { Timeline } from './Timeline'
+import { Metrics } from './Metrics'
 
+const projects = [
+  { id: 'PWA001', name: 'Hello World PWA', status: 'Completed', date: 'Dec 3, 2024' },
+  { id: 'PWA002', name: 'Voice Synthesis', status: 'Completed', date: 'Dec 4-5, 2024' },
+  { id: 'PWA003', name: 'Project Dashboard', status: 'Completed', date: 'Dec 6, 2024' },
+  { id: 'PWA004', name: 'Speech to Text', status: 'Completed', date: 'Dec 7-8, 2024' },
+  { id: 'PWA005', name: 'Claude Chat PWA', status: 'Completed', date: 'Dec 9, 2024' },
+  { id: 'PWA006', name: 'Voice AI Assistant', status: 'In Progress', date: 'Dec 10, 2024' }
+]
+
+export function Dashboard() {
   return (
-    <div className="p-6">
-      <header className="mb-8 flex items-center justify-between">
+    <div className="space-y-6 p-6">
+      <header className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-gray-900">Project Dashboard</h1>
           <p className="mt-2 text-sm text-gray-600">Project in a Day Progress Tracker</p>
         </div>
         <div className="w-24 h-24">
           <img 
-            src="/sleepy-owl.svg" 
+            src="/PWA003/sleepy-owl.svg" 
             alt="Sleepy owl" 
             className="w-full h-full"
             title="Time to rest! We'll continue tomorrow."
           />
         </div>
       </header>
-
-      <div className="grid gap-6 mb-8">
-        <div className="bg-white rounded-lg shadow">
-          <div className="p-6">
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">Project Status</h2>
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead>
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {projects.map((project) => (
-                    <tr key={project.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{project.id}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{project.name}</td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full 
-                          ${project.status === 'Completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
-                          {project.status}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{project.date}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <Metrics />
+        <Timeline projects={projects} />
       </div>
+      <ProjectList projects={projects} />
     </div>
-  );
+  )
 }

--- a/src/components/Metrics.tsx
+++ b/src/components/Metrics.tsx
@@ -1,35 +1,27 @@
-import { projects } from '../data/projects'
-
 export function Metrics() {
-  const completedProjects = projects.filter(p => p.status === 'completed').length
-  const inProgressProjects = projects.filter(p => p.status === 'in-progress').length
-  const plannedProjects = projects.filter(p => p.status === 'planned').length
-
-  // Calculate days active
-  const firstProject = projects.reduce((earliest, project) => {
-    return project.startDate < earliest.startDate ? project : earliest
-  })
-  const daysActive = Math.floor((new Date().getTime() - new Date(firstProject.startDate).getTime()) / (1000 * 60 * 60 * 24)) + 1
+  const metrics = {
+    total: 6,
+    completed: 5,
+    inProgress: 1
+  }
 
   return (
-    <div className="p-6 bg-white rounded-lg shadow">
-      <h2 className="text-xl font-semibold mb-4">Project Metrics</h2>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="p-4 bg-gray-50 rounded">
-          <div className="text-2xl font-bold text-blue-600">{completedProjects}</div>
-          <div className="text-sm text-gray-600">Completed</div>
-        </div>
-        <div className="p-4 bg-gray-50 rounded">
-          <div className="text-2xl font-bold text-green-600">{inProgressProjects}</div>
-          <div className="text-sm text-gray-600">In Progress</div>
-        </div>
-        <div className="p-4 bg-gray-50 rounded">
-          <div className="text-2xl font-bold text-purple-600">{plannedProjects}</div>
-          <div className="text-sm text-gray-600">Planned</div>
-        </div>
-        <div className="p-4 bg-gray-50 rounded">
-          <div className="text-2xl font-bold text-orange-600">{daysActive}</div>
-          <div className="text-sm text-gray-600">Days Active</div>
+    <div className="rounded-lg border bg-white text-gray-900 shadow-sm">
+      <div className="p-6 flex flex-col space-y-2">
+        <h2 className="text-2xl font-semibold">Project Metrics</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="p-4 bg-green-50 rounded-lg">
+            <h3 className="font-semibold text-green-600">Total Projects</h3>
+            <p className="text-2xl">{metrics.total}</p>
+          </div>
+          <div className="p-4 bg-blue-50 rounded-lg">
+            <h3 className="font-semibold text-blue-600">Completed</h3>
+            <p className="text-2xl">{metrics.completed}</p>
+          </div>
+          <div className="p-4 bg-yellow-50 rounded-lg">
+            <h3 className="font-semibold text-yellow-600">In Progress</h3>
+            <p className="text-2xl">{metrics.inProgress}</p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -1,61 +1,46 @@
-import { projects } from '../data/projects'
-
-const statusColors = {
-  'completed': 'bg-green-100 text-green-800',
-  'in-progress': 'bg-blue-100 text-blue-800',
-  'planned': 'bg-gray-100 text-gray-800'
+interface Project {
+  id: string
+  name: string
+  status: string
+  date: string
 }
 
-export function ProjectList() {
+interface ProjectListProps {
+  projects: Project[]
+}
+
+export function ProjectList({ projects }: ProjectListProps) {
   return (
-    <div className="bg-white rounded-lg shadow">
-      <div className="px-6 py-4 border-b">
-        <h2 className="text-xl font-semibold">Projects</h2>
-      </div>
-      <div className="divide-y">
-        {projects.map((project) => (
-          <div key={project.id} className="p-6">
-            <div className="flex justify-between items-start">
-              <div>
-                <h3 className="text-lg font-medium">{project.name}</h3>
-                <p className="mt-1 text-gray-600">{project.description}</p>
-              </div>
-              <span className={`px-3 py-1 rounded-full text-sm font-medium ${statusColors[project.status]}`}>
-                {project.status.charAt(0).toUpperCase() + project.status.slice(1)}
-              </span>
-            </div>
-            <div className="mt-4">
-              <h4 className="text-sm font-medium text-gray-500 mb-2">Features</h4>
-              <ul className="list-disc list-inside space-y-1 text-gray-600">
-                {project.features.map((feature, index) => (
-                  <li key={index} className="text-sm">{feature}</li>
-                ))}
-              </ul>
-            </div>
-            {project.repo && (
-              <div className="mt-4 flex space-x-4">
-                <a
-                  href={project.repo}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-blue-500 hover:text-blue-600"
-                >
-                  View Repository →
-                </a>
-                {project.demo && (
-                  <a
-                    href={project.demo}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-blue-500 hover:text-blue-600"
-                  >
-                    View Demo →
-                  </a>
-                )}
-              </div>
-            )}
-          </div>
-        ))}
+    <div className="rounded-lg border bg-white text-gray-900 shadow-sm">
+      <div className="p-6">
+        <h2 className="text-2xl font-semibold mb-4">Project Status</h2>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead>
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {projects.map((project) => (
+                <tr key={project.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{project.id}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{project.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full 
+                      ${project.status === 'Completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
+                      {project.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{project.date}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   )

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,43 +1,30 @@
-import { projects } from '../data/projects'
+interface Project {
+  id: string
+  name: string
+  status: string
+  date: string
+}
 
-export function Timeline() {
-  const timelineProjects = projects.filter(p => p.status !== 'planned')
+interface TimelineProps {
+  projects: Project[]
+}
 
+export function Timeline({ projects }: TimelineProps) {
   return (
-    <div className="p-6 bg-white rounded-lg shadow">
-      <h2 className="text-xl font-semibold mb-4">Project Timeline</h2>
-      <div className="space-y-4">
-        {timelineProjects.map((project) => (
-          <div key={project.id} className="flex items-start space-x-4">
-            <div className="min-w-[120px] text-sm text-gray-500">
-              {new Date(project.startDate).toLocaleDateString('en-US', { 
-                month: 'short',
-                day: 'numeric'
-              })}
-            </div>
-            <div className="flex-1">
-              <div className="flex items-center space-x-2">
-                <span className={`w-2 h-2 rounded-full ${
-                  project.status === 'completed' ? 'bg-green-500' : 'bg-blue-500'
-                }`} />
-                <h3 className="font-medium">{project.name}</h3>
+    <div className="rounded-lg border bg-white text-gray-900 shadow-sm">
+      <div className="p-6">
+        <h2 className="text-2xl font-semibold mb-4">Timeline</h2>
+        <div className="space-y-4">
+          {projects.map((project) => (
+            <div key={project.id} className="flex items-start">
+              <div className="flex-shrink-0 w-2 h-2 mt-2 rounded-full bg-blue-500" />
+              <div className="ml-4">
+                <p className="font-medium">{project.id}: {project.name}</p>
+                <p className="text-sm text-gray-500">{project.date}</p>
               </div>
-              <p className="mt-1 text-sm text-gray-600">{project.description}</p>
-              {project.status === 'completed' && (
-                <div className="mt-2">
-                  <a 
-                    href={project.demo} 
-                    target="_blank" 
-                    rel="noopener noreferrer"
-                    className="text-sm text-blue-500 hover:text-blue-600"
-                  >
-                    View Demo →
-                  </a>
-                </div>
-              )}
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
This PR restores the previous dashboard layout while maintaining current features:

- Split Dashboard into smaller components for better organization
- Add Timeline section to show project sequence
- Add Metrics section to show project statistics
- Keep current project status data including PWA006
- Keep sleepy owl image with fixed path
- Maintain Tailwind styling throughout

The changes improve the dashboard visualization while keeping all current functionality.