### PR TITLE
Add project links and navigation

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -2,13 +2,71 @@ import { ProjectList } from './ProjectList'
 import { Timeline } from './Timeline'
 import { Metrics } from './Metrics'
 
-const projects = [
-  { id: 'PWA001', name: 'Hello World PWA', status: 'Completed', date: 'Dec 3, 2024' },
-  { id: 'PWA002', name: 'Voice Synthesis', status: 'Completed', date: 'Dec 4-5, 2024' },
-  { id: 'PWA003', name: 'Project Dashboard', status: 'Completed', date: 'Dec 6, 2024' },
-  { id: 'PWA004', name: 'Speech to Text', status: 'Completed', date: 'Dec 7-8, 2024' },
-  { id: 'PWA005', name: 'Claude Chat PWA', status: 'Completed', date: 'Dec 9, 2024' },
-  { id: 'PWA006', name: 'Voice AI Assistant', status: 'In Progress', date: 'Dec 10, 2024' }
+export interface Project {
+  id: string
+  name: string
+  status: string
+  date: string
+  deploymentUrl: string
+  repoUrl: string
+  readmeUrl: string
+}
+
+const projects: Project[] = [
+  {
+    id: 'PWA001',
+    name: 'Hello World PWA',
+    status: 'Completed',
+    date: 'Dec 3, 2024',
+    deploymentUrl: 'https://magnazee.github.io/PWA001/',
+    repoUrl: 'https://github.com/Magnazee/PWA001',
+    readmeUrl: 'https://github.com/Magnazee/PWA001#readme'
+  },
+  {
+    id: 'PWA002',
+    name: 'Voice Synthesis',
+    status: 'Completed',
+    date: 'Dec 4-5, 2024',
+    deploymentUrl: 'https://magnazee.github.io/PWA002/',
+    repoUrl: 'https://github.com/Magnazee/PWA002',
+    readmeUrl: 'https://github.com/Magnazee/PWA002#readme'
+  },
+  {
+    id: 'PWA003',
+    name: 'Project Dashboard',
+    status: 'Completed',
+    date: 'Dec 6, 2024',
+    deploymentUrl: 'https://magnazee.github.io/PWA003/',
+    repoUrl: 'https://github.com/Magnazee/PWA003',
+    readmeUrl: 'https://github.com/Magnazee/PWA003#readme'
+  },
+  {
+    id: 'PWA004',
+    name: 'Speech to Text',
+    status: 'Completed',
+    date: 'Dec 7-8, 2024',
+    deploymentUrl: 'https://magnazee.github.io/PWA004/',
+    repoUrl: 'https://github.com/Magnazee/PWA004',
+    readmeUrl: 'https://github.com/Magnazee/PWA004#readme'
+  },
+  {
+    id: 'PWA005',
+    name: 'Claude Chat PWA',
+    status: 'Completed',
+    date: 'Dec 9, 2024',
+    deploymentUrl: 'https://magnazee.github.io/PWA005/',
+    repoUrl: 'https://github.com/Magnazee/PWA005',
+    readmeUrl: 'https://github.com/Magnazee/PWA005#readme'
+  },
+  {
+    id: 'PWA006',
+    name: 'Voice AI Assistant',
+    status: 'In Progress',
+    date: 'Dec 10, 2024',
+    deploymentUrl: 'https://magnazee.github.io/PWA006/',
+    repoUrl: 'https://github.com/Magnazee/PWA006',
+    readmeUrl: 'https://github.com/Magnazee/PWA006#readme'
+  }
 ]
 
 export function Dashboard() {

--- a/src/components/ProjectList.tsx
+++ b/src/components/ProjectList.tsx
@@ -1,9 +1,5 @@
-interface Project {
-  id: string
-  name: string
-  status: string
-  date: string
-}
+import { Link } from 'lucide-react'
+import { type Project } from './Dashboard'
 
 interface ProjectListProps {
   projects: Project[]
@@ -11,7 +7,7 @@ interface ProjectListProps {
 
 export function ProjectList({ projects }: ProjectListProps) {
   return (
-    <div className="rounded-lg border bg-white text-gray-900 shadow-sm">
+    <div className="rounded-lg border bg-white text-gray-900 shadow-sm" id="project-list">
       <div className="p-6">
         <h2 className="text-2xl font-semibold mb-4">Project Status</h2>
         <div className="overflow-x-auto">
@@ -20,22 +16,58 @@ export function ProjectList({ projects }: ProjectListProps) {
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Links</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
               {projects.map((project) => (
-                <tr key={project.id} className="hover:bg-gray-50">
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{project.id}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{project.name}</td>
+                <tr key={project.id} id={`project-${project.id}`} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                    {project.id}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-blue-600 hover:text-blue-800">
+                    <a 
+                      href={project.deploymentUrl} 
+                      target="_blank" 
+                      rel="noopener noreferrer"
+                    >
+                      {project.name}
+                    </a>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <div className="flex space-x-2">
+                      <a 
+                        href={project.repoUrl} 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-800 flex items-center"
+                        title="View Repository"
+                      >
+                        <Link className="w-4 h-4" />
+                        <span className="sr-only">Repository</span>
+                      </a>
+                      <a 
+                        href={project.readmeUrl} 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-800"
+                        title="View README"
+                      >
+                        README
+                      </a>
+                    </div>
+                  </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full 
                       ${project.status === 'Completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}>
                       {project.status}
                     </span>
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{project.date}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    {project.date}
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,9 +1,4 @@
-interface Project {
-  id: string
-  name: string
-  status: string
-  date: string
-}
+import { type Project } from './Dashboard'
 
 interface TimelineProps {
   projects: Project[]
@@ -19,7 +14,12 @@ export function Timeline({ projects }: TimelineProps) {
             <div key={project.id} className="flex items-start">
               <div className="flex-shrink-0 w-2 h-2 mt-2 rounded-full bg-blue-500" />
               <div className="ml-4">
-                <p className="font-medium">{project.id}: {project.name}</p>
+                <a 
+                  href={`#project-${project.id}`}
+                  className="font-medium text-blue-600 hover:text-blue-800"
+                >
+                  {project.id}: {project.name}
+                </a>
                 <p className="text-sm text-gray-500">{project.date}</p>
               </div>
             </div>


### PR DESCRIPTION
This PR adds linking and navigation features to the dashboard:

Changes:
- Add deploymentUrl, repoUrl, and readmeUrl to Project interface
- Link project names to their deployment URLs (opens in new window)
- Add repository and README links to each project
- Link timeline entries to project list items using fragment identifiers
- Add lucide-react Link icon for repository links
- Configure all external links to open in new windows with proper security attributes
- Add hover states and proper styling for all links
- Maintain existing layout and functionality